### PR TITLE
Pubd 1077 fix id errors

### DIFF
--- a/Classes/Builder/Mapper/DataObject/ArticleFile.php
+++ b/Classes/Builder/Mapper/DataObject/ArticleFile.php
@@ -120,6 +120,6 @@ class ArticleFile  extends AbstractDataObjectMapper {
      * @return string
      */
     protected static function generateSourceRecordKey($modelName, $articleId, $fileId, $revision) {
-        return $modelName.':'.$articleId.':'.$fileId.'-'.($revision ?: '0');
+        return $modelName.':'.$articleId.':'.$fileId.'-'.(sprintf('%02d', $revision) ?: '00');
     }
 }

--- a/Classes/Builder/Mapper/DataObject/ArticleFile.php
+++ b/Classes/Builder/Mapper/DataObject/ArticleFile.php
@@ -96,7 +96,7 @@ class ArticleFile  extends AbstractDataObjectMapper {
      * @return string
      */
     protected static function getSourceRecordKey($model) {
-        return self::generateSourceRecordKey(get_class($model), $model->getArticleId(), $model->getFileId(), $model->getRevision());
+        return self::generateSourceRecordKey("ArticleFile", $model->getArticleId(), $model->getFileId(), $model->getRevision());
     }
 
     /**

--- a/Classes/Builder/Mapper/DataObject/ReviewAssignment.php
+++ b/Classes/Builder/Mapper/DataObject/ReviewAssignment.php
@@ -34,7 +34,7 @@ class ReviewAssignment extends AbstractDataObjectMapper {
         ['property' => 'replaced', 'filters' => ['boolean']],
         ['property' => 'cancelled', 'filters' => ['boolean']],
         ['property' => 'reviewFiles', 'source' => 'reviewFileForRound', 'context' => 'sourceRecordKey'],
-        ['property' => 'suppFiles', 'source' => 'supplementaryFiles'],
+        ['property' => 'suppFiles', 'source' => 'supplementaryFiles', 'context' => 'sourceRecordKey'],
         ['property' => 'reviewerFile', 'context' => 'sourceRecordKey'],
         ['property' => 'comments', 'source' => 'reviewComments'],
         ['property' => 'quality', 'source' => 'qualityText'],


### PR DESCRIPTION
- Supplemental file IDs don't use the SuppFile prefix when they are created so it shouldn't be used when they are references
- We don't need to report all of the supp file fields in the review assignment just the reference
- Pad revision numbers in article file ids with 0s so when they are processed in alpha order by the journal transporter smaller numbers will be processed first

All these changes have been tested in dev on recent migrations.